### PR TITLE
Add playlist length & position in playlist of a song to formatter

### DIFF
--- a/spotdl/console/download.py
+++ b/spotdl/console/download.py
@@ -29,7 +29,7 @@ def download(
         songs = []
         for song in songs_list:
             song_path = create_file_name(
-                song, downloader.output, downloader.output_format
+                song, downloader.output, downloader.output_format, song_list=songs_list
             )
 
             if Path(song_path).exists():

--- a/spotdl/utils/m3u.py
+++ b/spotdl/utils/m3u.py
@@ -12,7 +12,12 @@ def create_m3u_content(
     """
     text = ""
     for song in songs:
-        text += str(create_file_name(song, template, file_extension, short)) + "\n"
+        text += (
+            str(
+                create_file_name(song, template, file_extension, short, song_list=songs)
+            )
+            + "\n"
+        )
 
     return text
 

--- a/tests/utils/test_formatter.py
+++ b/tests/utils/test_formatter.py
@@ -86,6 +86,18 @@ def test_create_file_name():
         "GB2LD2110301/Ropes - Dirty Palm....mp3"
     )
 
+    assert create_file_name(song, "{list-position}/{list-length} {title} - {artist}", "mp3",song_list=[song, 1, 2]) == Path(
+        "1/3 Ropes - Dirty Palm.mp3"
+    )
+
+    assert create_file_name(song, "{list-position}/{list-length} {title} - {artist}", "mp3",song_list=[song, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) == Path(
+        "01/11 Ropes - Dirty Palm.mp3"
+    )
+
+    assert create_file_name(song, "{list-position}/{list-length} {title} - {artist}", "mp3",song_list=[1, 2, 3, 4, song, 6, 7, 8, 9, 10, 11]) == Path(
+        "05/11 Ropes - Dirty Palm.mp3"
+    )
+
 
 def test_parse_duration():
     """


### PR DESCRIPTION
# Title
Added the playlist length and song position in playlist to the formatter

## Description
Allow user to download songs of a spotify playlist and use the songs position (and maybe playlist length) in the output filename generated for the song.

A use case would be to keep the song in the same order as in the playlist, and using the position a user could simply prefix the filename with "{list-position}" to keeps all the songs ordered.

## Related Issue
https://github.com/spotDL/spotdl-v4/issues/9

## Motivation and Context
I needed to keep songs ordered the same way compared to the playlist that I was downloading, but there was no way to do that (the only position info I have is the position in the Album, but in the case of playlist mixing album, it is not very useful).

## How Has This Been Tested?

I've tested this code with a simple test playlist of 2 songs from spotify.

## Screenshots (if appropriate)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [ ] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
