### PR TITLE
Added option --restrict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,4 @@
+from setuptools import setup
+
+if __name__ == "__main__":
+    setup()

--- a/spotdl/__init__.py
+++ b/spotdl/__init__.py
@@ -35,6 +35,7 @@ class Spotdl:
         search_query: str = "{artist} - {title}",
         log_level: str = "INFO",
         simple_tui: bool = False,
+        restrict: bool = False,
     ):
         # Initialize spotify client
         SpotifyClient.init(
@@ -59,6 +60,7 @@ class Spotdl:
             filter_results=filter_results,
             log_level=log_level,
             simple_tui=simple_tui,
+            restrict=restrict,
         )
 
         self.audio_provider = audio_provider

--- a/spotdl/console/entry_point.py
+++ b/spotdl/console/entry_point.py
@@ -109,6 +109,7 @@ def console_entry_point():
             cookie_file=settings["cookie_file"],
             log_level=settings["log_level"],
             simple_tui=settings["simple_tui"],
+            restrict=settings["restrict"],
         )
 
         def graceful_exit(_signal, _frame):

--- a/spotdl/console/web.py
+++ b/spotdl/console/web.py
@@ -204,6 +204,7 @@ def change_settings(settings: SettingsModel) -> bool:
         log_level="CRITICAL",
         simple_tui=True,
         # loop=app.loop,
+        restrict=settings["restrict"],
     )
 
     return True
@@ -232,6 +233,7 @@ def web(settings: Dict[str, Any]):
         log_level="CRITICAL",
         simple_tui=True,
         loop=loop,
+        restrict=settings["restrict"],
     )
 
     config = Config(app=app.server, port=8800, workers=1, loop=loop)  # type: ignore

--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -13,7 +13,7 @@ from spotdl.types import Song
 from spotdl.utils.ffmpeg import FFmpeg
 from spotdl.utils.ffmpeg import FFmpegError
 from spotdl.utils.metadata import embed_metadata
-from spotdl.utils.formatter import create_file_name
+from spotdl.utils.formatter import create_file_name, restrict_filename
 from spotdl.providers.audio.base import AudioProvider
 from spotdl.providers.lyrics import Genius, MusixMatch, AzLyrics
 from spotdl.providers.lyrics.base import LyricsProvider
@@ -60,6 +60,7 @@ class Downloader:
         log_level: str = "INFO",
         simple_tui: bool = False,
         loop: Optional[asyncio.AbstractEventLoop] = None,
+        restrict: bool = False,
     ):
         """
         Initialize the Downloader class.
@@ -113,6 +114,7 @@ class Downloader:
             constant_bitrate=constant_bitrate,
             ffmpeg_args=["-v", "debug"] if ffmpeg_args is None else ffmpeg_args,
         )
+        self.restrict = restrict
 
         self.progress_handler = ProgressHandler(NAME_TO_LEVEL[log_level], simple_tui)
 
@@ -222,6 +224,10 @@ class Downloader:
             output_file = create_file_name(
                 song, self.output, self.output_format, song_list=song_list
             )
+
+            if self.restrict is not None:
+                output_file = restrict_filename(output_file)
+
             if output_file.exists() is False:
                 output_file.parent.mkdir(parents=True, exist_ok=True)
 

--- a/spotdl/utils/arguments.py
+++ b/spotdl/utils/arguments.py
@@ -274,6 +274,15 @@ def parse_output_options(parser: _ArgumentGroup):
         help="Overwrite existing files.",
     )
 
+    # Option to restrict filenames for easier handling in the shell
+    parser.add_argument(
+        "--restrict",
+        default=DEFAULT_CONFIG["restrict"],
+        help="Restrict filenames to ASCII only",
+        action="store_true"
+    )
+
+
 
 def parse_misc_options(parser: _ArgumentGroup):
     """

--- a/spotdl/utils/config.py
+++ b/spotdl/utils/config.py
@@ -101,4 +101,5 @@ DEFAULT_CONFIG = {
     "no_cache": False,
     "cookie_file": None,
     "headless": False,
+    "restrict": False,
 }

--- a/spotdl/utils/formatter.py
+++ b/spotdl/utils/formatter.py
@@ -1,4 +1,5 @@
 import re
+import itertools
 
 from typing import List, Optional
 from pathlib import Path
@@ -215,3 +216,58 @@ def slugify(value: str, to_lower=True) -> str:
     """
 
     return Slugify(to_lower=to_lower)(value)
+
+
+# needed for sanitizing filenames in restricted mode
+ACCENT_CHARS = dict(zip('ÂÃÄÀÁÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖŐØŒÙÚÛÜŰÝÞßàáâãäåæçèéêëìíîïðñòóôõöőøœùúûüűýþÿ',
+                        itertools.chain('AAAAAA', ['AE'], 'CEEEEIIIIDNOOOOOOO', ['OE'], 'UUUUUY', ['TH', 'ss'],
+                                        'aaaaaa', ['ae'], 'ceeeeiiiionooooooo', ['oe'], 'uuuuuy', ['th'], 'y')))
+
+def restrict_filename(pathobj):
+    """Sanitizes a string so it could be used as part of a filename.
+    If restricted is set, use a stricter subset of allowed characters.
+    Set is_id if this is not an arbitrary string, but an ID that should be kept
+    if possible.
+    """
+    # from: https://github.com/ytdl-org/youtube-dl/blob/master/youtube_dl/utils.py
+    def replace_insane(char):
+        if char in ACCENT_CHARS:
+            return ACCENT_CHARS[char]
+        if char == '?' or ord(char) < 32 or ord(char) == 127:
+            return ''
+        elif char == '"':
+            return ''
+        elif char == ':':
+            return '_-'
+        elif char in '\\/|*<>':
+            return '_'
+        if (char in '!&\'()[]{}$;`^,#' or char.isspace()):
+            return '_'
+        if ord(char) > 127:
+            return '_'
+        return char
+
+    # Handle timestamps
+    result = re.sub(r'[0-9]+(?::[0-9]+)+', lambda m: m.group(0).replace(':', '_'), pathobj.name)
+
+    # apply replacements
+    result = ''.join(map(replace_insane, result))
+
+    while '__' in result:
+        result = result.replace('__', '_')
+
+    result = result.strip('_')
+    # Common case of "Foreign band name - English song title"
+    if result.startswith('-_'):
+        result = result[2:]
+
+    if result.startswith('-'):
+        result = '_' + result[len('-'):]
+
+    result = result.lstrip('.')
+    result = result.replace('_-_', '-')
+
+    if not result:
+        result = '_'
+
+    return pathobj.with_name(result)

--- a/spotdl/utils/formatter.py
+++ b/spotdl/utils/formatter.py
@@ -218,8 +218,9 @@ def slugify(value: str, to_lower=True) -> str:
     return Slugify(to_lower=to_lower)(value)
 
 
-def restrict_filename(pathobj):
-    """Sanitizes the filename part of a Path object. Returns modified object.
+def restrict_filename(pathobj: Path) -> Path:
+    """
+    Sanitizes the filename part of a Path object. Returns modified object.
     """
 
     result = sanitize_filename(pathobj.name, True, False)


### PR DESCRIPTION
# Title
Primary function has been taken from youtube-dl to sanitize filenames.

## Description
As a pure commandline user managing large quantities of files which contain spaces, non-printable characters etc is a pain. Youtube-dl has this option for a long time and since spotdl does basically the same thing, it seemed naturally for me to have the option here as well.

## Motivation and Context
It makes managing and usage of downloaded files easier, e.g.:
`mplayer Dublicator*`

When doing the same thing with filenames containing whitespaces, this doesn't work, one needs to escape them or modify IFS or whatever.

## How Has This Been Tested?
I downloaded a spotify song using the parameter `--restrict` which created a sanitized filename:
```
% python -m spotdl download https://open.spotify.com/track/1LjbYVflsVocbrqoxZ10ME --restrict
[..]

% ls -l *.mp3
-rw-r--r-- 1 user user 5784261 Mar 16 18:47 Dublicator-Elasticity.mp3
```

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] My code follows the code style of this project
- [X] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [X] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
  There are 2 failing tests, but they also fail w/o my changes, so I think these are unrelated
