### PR TITLE
Fix AZLyrics provider

### DIFF
--- a/spotdl/providers/lyrics/azlyrics.py
+++ b/spotdl/providers/lyrics/azlyrics.py
@@ -63,7 +63,7 @@ class AzLyrics(LyricsProvider):
 
         # Find the div with the longest text
         lyrics_div = sorted(div_tags, key=lambda x: len(x.text))[-1]
-        
+
         lyrics = lyrics_div.get_text()
 
         # Remove the 3 first new lines

--- a/spotdl/providers/lyrics/azlyrics.py
+++ b/spotdl/providers/lyrics/azlyrics.py
@@ -61,7 +61,10 @@ class AzLyrics(LyricsProvider):
         # Find all divs that don't have a class
         div_tags = soup.find_all("div", class_=False, id_=False)
 
-        lyrics = div_tags[1].get_text()
+        # Find the div with the longest text
+        lyrics_div = sorted(div_tags, key=lambda x: len(x.text))[-1]
+        
+        lyrics = lyrics_div.get_text()
 
         # Remove the 3 first new lines
         lyrics = lyrics[3:]


### PR DESCRIPTION

# Title
Fix the criteria for finding the lyrics element of AZLyrics provider

## Description
For the AZLyrics provider, it's better to get the lyrics div based on the elements' text length, I got no result for `AzLyrics().get_lyrics("bad guy", ["Billie Eilish"])`, and this fixed the problem

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/spotDL/spotdl-v4/issues/14#issue-1235948890

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This commit fixes the issue of finding a lyrics from the "AZLyrics" provider since the previous method had a bug to find the element containing lyrics text. As I said in the issue it's better to get the lyrics div based on the elements' text length, not just an index like [div_tags[1]](https://github.com/spotDL/spotdl-v4/blob/master/spotdl/providers/lyrics/azlyrics.py#L64) (current code) since there might be more elements in the future on the provider website like this issue.

## How Has This Been Tested?
Calling `AzLyrics().get_lyrics("bad guy", ["Billie Eilish"])` (a song that hadn't any result with the previous code) and getting the proper lyrics

## Screenshots (if appropriate)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
